### PR TITLE
Fixed broken sidebar menu

### DIFF
--- a/research-software/overview.rst
+++ b/research-software/overview.rst
@@ -16,8 +16,8 @@ reports, white papers), links to instruction manuals and further information.
 Centrally supported packages
 ----------------------------
 
-ARCHER2 provides a number of research software packages as `centrally
-supported packages`. Many of these packages are free to use, but others
+ARCHER2 provides a number of research software packages as *centrally
+supported packages*. Many of these packages are free to use, but others
 require a license (which you, or your research group, need to supply).
 
 The centrally supported package will usually be the current stable release,
@@ -28,27 +28,24 @@ of the package.
 The following sections provide details on access to each of the centrally
 supported packages:
 
-.. toctree::
-   :maxdepth: 2
-
-   castep/castep.rst
-   code-saturne/code-saturne.rst
-   chemshell/chemshell.rst
-   cp2k/cp2k.rst
-   elk/elk.rst
-   fenics/fenics.rst
-   gromacs/gromacs.rst
-   lammps/lammps.rst
-   mo-unified-model/mo-unified-model.rst
-   mitgcm/mitgcm.rst
-   namd/namd.rst
-   nektar++/nektar++.rst
-   nemo/nemo.rst
-   nwchem/nwchem.rst
-   onetep/onetep.rst
-   openfoam/openfoam.rst
-   qe/qe.rst
-   vasp/vasp.rst
+- :doc:`castep/castep`
+- :doc:`code-saturne/code-saturne`
+- :doc:`chemshell/chemshell`
+- :doc:`cp2k/cp2k`
+- :doc:`elk/elk`
+- :doc:`fenics/fenics`
+- :doc:`gromacs/gromacs`
+- :doc:`lammps/lammps`
+- :doc:`mo-unified-model/mo-unified-model`
+- :doc:`mitgcm/mitgcm`
+- :doc:`namd/namd`
+- :doc:`nektar++/nektar++`
+- :doc:`nemo/nemo`
+- :doc:`nwchem/nwchem`
+- :doc:`onetep/onetep`
+- :doc:`openfoam/openfoam`
+- :doc:`qe/qe`
+- :doc:`vasp/vasp`
 
 Not on the list?
 ^^^^^^^^^^^^^^^^

--- a/user-guide/overview.rst
+++ b/user-guide/overview.rst
@@ -8,18 +8,18 @@ Overview
 
 The ARCHER2 User and Best Practice Guide covers all aspects of use of the ARCHER2 service. This includes fundamentals
 (required by all users to use the system effectively), best practice for getting the most out of
-ARCHER2, and more advanced technical topics. 
+ARCHER2 and more advanced technical topics. 
 
-User guide sections, as specified in the bid document:
+The User and Best Practice Guide contains the following sections:
 
-- Interactive access
-- Data management and transfer
-- Using pre-installed software
-- Using the scheduler
-- Data I/O
-- Application development environment
-- Using Containers
-- Using Python
-- Data Analysis, pre- and post-processing
-- Debugging
-- Profiling, benchmarking and understanding performance
+- :doc:`connecting`
+- :doc:`data`
+- :doc:`sw-environment`
+- :doc:`scheduler`
+- :doc:`io`
+- :doc:`dev-environment`
+- :doc:`containers`
+- :doc:`python`
+- :doc:`analysis`
+- :doc:`debug`
+- :doc:`profile`


### PR DESCRIPTION
The inclusion of a toctree in the second level research-software/overview was causing the sidebar menu to break. Changed to a standard list of contents on the overview page. Also added contents to the User and BP Guide overview page to match.