### PR TITLE
Update scheduler.rst

### DIFF
--- a/user-guide/scheduler.rst
+++ b/user-guide/scheduler.rst
@@ -178,7 +178,7 @@ Other common options that are used are:
 
   - ``--time=<hh:mm:ss>`` the maximum walltime for your job. *e.g.* For a 6.5 hour
     walltime, you would use ``--time=6:30:0``.
-  - ``--name=<jobname>`` set a name for the job to help identify it in 
+  - ``--job-name=<jobname>`` set a name for the job to help identify it in 
     Slurm command output.
 
 In addition, parallel jobs will also need to specify how many nodes,
@@ -233,7 +233,7 @@ nodes and 128 MPI ranks per node for 20 minutes would look like:
     #!/bin/bash
 
     # Slurm job options (name, compute nodes, job time)
-    #SBATCH --name=Example_MPI_Job
+    #SBATCH --job-name=Example_MPI_Job
     #SBATCH --time=0:20:0
     #SBATCH --nodes=4
     #SBATCH --tasks-per-node=128
@@ -284,7 +284,7 @@ process. This results in all 128 physical cores per node being used.
     #!/bin/bash
 
     # Slurm job options (name, compute nodes, job time)
-    #SBATCH --name=Example_MPI_Job
+    #SBATCH --job-name=Example_MPI_Job
     #SBATCH --time=0:20:0
     #SBATCH --nodes=4
     #SBATCH --ntasks=32
@@ -334,7 +334,7 @@ process per core and specifies 4 hours maximum runtime per subjob:
 
     #!/bin/bash
     # Slurm job options (name, compute nodes, job time)
-    #SBATCH --name=Example_Array_Job
+    #SBATCH --job-name=Example_Array_Job
     #SBATCH --time=0:20:0
     #SBATCH --nodes=4
     #SBATCH --tasks-per-node=128


### PR DESCRIPTION
I think the `--name` flag should be `--job-name`. I received an error when submitting a modified version of the submission files saying the name flag wasn't recognised, and it doesn't appear as an option if you use `sbatch --help`. Changing to `--job-name` seemed to fix this.