### PR TITLE
Add `epcc-job-env` module to example scripts

### DIFF
--- a/quick-start/quickstart-developers.rst
+++ b/quick-start/quickstart-developers.rst
@@ -92,7 +92,7 @@ provides AMD Clang/Clang++ and AMD Flang.
 
 .. note::
 
-  Unlike ARCHER, the Intel compilers are not available on ARCHER2.
+  The Intel compilers are not available on ARCHER2.
 
 
 

--- a/quick-start/quickstart-users.rst
+++ b/quick-start/quickstart-users.rst
@@ -355,9 +355,14 @@ your budget code e.g. ``e99-ham``, ``ENTER_PARTITION_HERE`` with the partition y
   #SBATCH --tasks-per-node=128
   #SBATCH --cpus-per-task=1
   #SBATCH --time=0:5:0
-  #SBATCH --account=ENTER_YOUR_BUDGET_CODE_HERE
-  #SBATCH --partition=ENTER_PARTITION_HERE
-  #SBATCH --qos=ENTER_QOS_HERE
+
+  # Replace [budget code] below with your project code (e.g. t01)
+  #SBATCH --account=[budget code]
+  #SBATCH --partition=standard
+  #SBATCH --qos=standard
+
+  # Setup the batch environment
+  module load epcc-job-env
 
   # Load the xthi module to get access to the xthi program
   module load xthi

--- a/research-software/castep/castep.rst
+++ b/research-software/castep/castep.rst
@@ -44,21 +44,19 @@ assumes that the input files have the file stem ``text_calc``.
   #!/bin/bash
 
   # Request 2 nodes with 128 MPI tasks per node for 20 minutes
-  # Replace [budget code] below with your account code,
-  # e.g. '--account=t01'
-
   #SBATCH --job-name=CASTEP
   #SBATCH --nodes=2
   #SBATCH --tasks-per-node=128
   #SBATCH --cpus-per-task=1
   #SBATCH --time=00:20:00
-
-  #SBATCH --partition=standard
-  #SBATCH --qos=standard
   
+  # Replace [budget code] below with your project code (e.g. t01)
   #SBATCH --account=[budget code]
   #SBATCH --partition=standard
   #SBATCH --qos=standard
+
+  # Setup the batch environment
+  module load epcc-job-env
 
   # Load the CASTEP module, avoid any unintentional OpenMP threading by
   # setting OMP_NUM_THREADS, and launch the code.

--- a/research-software/chemshell/chemshell.rst
+++ b/research-software/chemshell/chemshell.rst
@@ -51,7 +51,7 @@ Py-ChemShell
 
 .. warning::
 
-  Example scripts are pending
+  Example scripts will be added soon.
 
 ::
 

--- a/research-software/code-saturne/code-saturne.rst
+++ b/research-software/code-saturne/code-saturne.rst
@@ -73,12 +73,14 @@ for a maximum of 20 minutes.
   #SBATCH --tasks-per-node=128
   #SBATCH --cpus-per-task=1
 
-  # Replace [budget code] below with your budget code (e.g. t01)
+  # Replace [budget code] below with your project code (e.g. t01)
   #SBATCH --account=[budget code]
   #SBATCH --partition=standard
   #SBATCH --qos=standard
 
-  module -s restore /etc/cray-pe.d/PrgEnv-gnu
+  # Setup the batch environment
+  module load epcc-job-env
+  
   module load code_saturne
 
   # Prevent threading.

--- a/research-software/cp2k/cp2k.rst
+++ b/research-software/cp2k/cp2k.rst
@@ -60,33 +60,29 @@ For example, the following script will run a CP2K job using 4 nodes
 
 ::
 
-   #!/bin/bash --login
+  #!/bin/bash
 
-   # Request 4 nodes using 128 cores per node for 128 MPI tasks per node.
-   # Replace [budget code] below with your project code (e.g. t01)
+  # Request 4 nodes using 128 cores per node for 128 MPI tasks per node.
 
+  #SBATCH --job-name=CP2K_test
+  #SBATCH --nodes=4
+  #SBATCH --tasks-per-node=128
+  #SBATCH --cpus-per-task=1
+  #SBATCH --time=00:20:00
 
-   #SBATCH --job-name=CP2K_test
-   #SBATCH --nodes=4
-   #SBATCH --ntasks=512
-   #SBATCH --tasks-per-node=128
-   #SBATCH --cpus-per-task=1
-   #SBATCH --time=00:20:00
+  # Replace [budget code] below with your project code (e.g. t01)
+  #SBATCH --account=[budget code]
+  #SBATCH --partition=standard
+  #SBATCH --qos=standard
 
-   #SBATCH --account=[budget code]
-   #SBATCH --partition=standard
-   #SBATCH --qos=standard
+  # Setup the batch environment
+  module load epcc-job-env
 
-   # Load the relevant CP2K module
-   # Ensure that no libraries are inadvertently using threading
-   # Launch the executable
+  module load cp2k
 
-   module -s restore /etc/cray-pe.d/PrgEnv-gnu
-   module load cp2k
+  export OMP_NUM_THREADS=1
 
-   export OMP_NUM_THREADS=1
-
-   srun cp2k.popt -i MYINPUT.inp
+  srun cp2k.popt -i MYINPUT.inp
 
 
 MPI/OpenMP hybrid jobs

--- a/research-software/elk/elk.rst
+++ b/research-software/elk/elk.rst
@@ -45,31 +45,28 @@ The following script will run an ELK job on 4 nodes (512 cores).
 
 ::
 
-   #!/bin/bash
+  #!/bin/bash
 
-   # Request 512 MPI tasks (4 nodes at 128 tasks per node) with a
-   # maximum wall clock time limit of 20 minutes.
-   # Replace [budget code] with your account code.
+  # Request 512 MPI tasks (4 nodes at 128 tasks per node) with a
+  # maximum wall clock time limit of 20 minutes.
 
-   #SBATCH --job-name=elk_job
-   #SBATCH --nodes=4
-   #SBATCH --ntasks=512
-   #SBATCH --tasks-per-node=128
-   #SBATCH --cpus-per-task=1
-   #SBATCH --time=00:20:00
+  #SBATCH --job-name=elk_job
+  #SBATCH --nodes=4
+  #SBATCH --tasks-per-node=128
+  #SBATCH --cpus-per-task=1
+  #SBATCH --time=00:20:00
 
-   #SBATCH --account=[budget code]
-   #SBATCH --partition=standard
-   #SBATCH --qos=standard
+  # Replace [budget code] below with your project code (e.g. t01)
+  #SBATCH --account=[budget code]
+  #SBATCH --partition=standard
+  #SBATCH --qos=standard
 
-   # Load the elk module
-   # Launch the executable 
-   # Input filename elk.in
+  # Setup the batch environment
+  module load epcc-job-env
 
-   module -s restore /etc/cray-pe.d/PrgEnv-gnu
-   module load elk
+  module load elk
 
-   srun elk 
+  srun --cpu-bind=cores elk 
 
 
 Mixed MPI/OpenMP ELK jobs

--- a/research-software/gromacs/gromacs.rst
+++ b/research-software/gromacs/gromacs.rst
@@ -45,7 +45,7 @@ The following script will run a GROMACS MD job using 4 nodes
 ::
 
    #!/bin/bash
-   
+
    # Replace [budget code] below with your project code (e.g. t01)
 
    #SBATCH --job-name=mdrun_test
@@ -54,18 +54,19 @@ The following script will run a GROMACS MD job using 4 nodes
    #SBATCH --tasks-per-node=128
    #SBATCH --cpus-per-task=1
    #SBATCH --time=00:20:00
-   
+
+   # Replace [budget code] below with your project code (e.g. t01)
    #SBATCH --account=[budget code]
-   
    #SBATCH --partition=standard
    #SBATCH --qos=standard
-   
-   # Load the relevant GROMACS module
-   module restore /etc/cray-pe.d/PrgEnv-gnu
+
+   # Setup the batch environment
+   module load epcc-job-env
+
    module load gromacs
 
    export OMP_NUM_THREADS=1 
-   srun gmx_mpi mdrun -s test_calc.tpr
+   srun --cpu-bind=cores gmx_mpi mdrun -s test_calc.tpr
 
 
 Running hybrid MPI/OpenMP jobs
@@ -78,9 +79,6 @@ total) and 6 OpenMP threads per MPI process.
 ::
 
    #!/bin/bash
-   
-   # Replace [budget code] below with your project code (e.g. t01)
-
    #SBATCH --job-name=mdrun_test
    #SBATCH --nodes=4
    #SBATCH --ntasks=64
@@ -88,20 +86,18 @@ total) and 6 OpenMP threads per MPI process.
    #SBATCH --cpus-per-task=8
    #SBATCH --time=00:20:00
 
+   # Replace [budget code] below with your project code (e.g. t01)
    #SBATCH --account=[budget code]
    #SBATCH --partition=standard
    #SBATCH --qos=standard
-   
-   # Load the relevant GROMACS module
-   module restore /etc/cray-pe.d/PrgEnv-gnu
+
+   # Setup the batch environment
+   module load epcc-job-env
+
    module load gromacs
 
    export OMP_NUM_THREADS=8
-   srun gmx_mpi mdrun -s test_calc.tpr
-
-
-Hints and Tips
---------------
+   srun --hint=nomultithread --distribution=block:block gmx_mpi mdrun -s test_calc.tpr
 
 
 Compiling Gromacs

--- a/research-software/lammps/lammps.rst
+++ b/research-software/lammps/lammps.rst
@@ -28,7 +28,7 @@ LAMMPS is freely available to all ARCHER2 users.
 The centrally installed version of LAMMPS is compiled with all the
 standard packages included: `ASPHERE`, `BODY`, `CLASS2`, `COLLOID`, 
 `COMPRESS`, `CORESHELL`, `DIPOLE`, `GRANULAR`, `KSPACE`, `MANYBODY`,
-'MC`, `MISC`, `MOLECULE`, `OPT`, `PERI`, `QEQ`, `REPLICA`, `RIGID`, 
+`MC`, `MISC`, `MOLECULE`, `OPT`, `PERI`, `QEQ`, `REPLICA`, `RIGID`, 
 `SHOCK`, `SNAP`, `SRD`.
 
 We do not install any `USER` packages. If you are interested in a `USER`
@@ -45,40 +45,33 @@ exclusive mode using more than one node.
 For example, the following script will run a LAMMPS MD job using 4 nodes
 (128x4 cores) with MPI only.
 
-.. warning::
-
-  The following script is provisional and needs to be verified
-
 ::
 
-   #!/bin/bash --login
+  #!/bin/bash
 
-   #SBATCH --job-name=lammps_test
-   #SBATCH --nodes=4
-   #SBATCH --ntasks=512
-   #SBATCH --tasks-per-node=128
-   #SBATCH --cpus-per-task=1
-   #SBATCH --time=00:20:00
-   
-   # Replace [budget code] below with your project code (e.g. t01)
-   #SBATCH --account=[budget code]
-   #SBATCH --partition=standard
-   #SBATCH --qos=standard
-   
-   # Load the relevant LAMMPS module
-   module restore /etc/cray-pe.d/PrgEnv-gnu
-   module load lammps
+  #SBATCH --job-name=lammps_test
+  #SBATCH --nodes=4
+  #SBATCH --ntasks=512
+  #SBATCH --tasks-per-node=128
+  #SBATCH --cpus-per-task=1
+  #SBATCH --time=00:20:00
 
-   srun lmp -i in.test -o out.test
+  # Replace [budget code] below with your project code (e.g. t01)
+  #SBATCH --account=[budget code] 
+  #SBATCH --partition=standard
+  #SBATCH --qos=standard
 
+  # Setup the job environment (this module needs to be loaded before any other modules)
+  module load epcc-job-env
 
-Hints and Tips
---------------
+  module load lammps
+
+  srun --cpu-bind=cores lmp -i in.test -o out.test
 
 Compiling LAMMPS
 ----------------
 
-The large range of optional packages availble for LAMMPS, and opportunity
+The large range of optional packages available for LAMMPS, and opportunity
 for extensibility,  may mean that it is convenient for users to compile
 their own copy. In practice, LAMMPS is relatively easy to compile, so we
 encourage users to have a go.

--- a/research-software/mitgcm/mitgcm.rst
+++ b/research-software/mitgcm/mitgcm.rst
@@ -93,14 +93,13 @@ a pure MPI MITgcm simulation over 2 nodes of 128 cores each for up to one hour.
   #SBATCH --tasks-per-node=128
   #SBATCH --cpus-per-task=1
 
-  # Replace [budget code] below with your budget code (e.g. t01)
-  #SBATCH --account=[budget code]
+  # Replace [budget code] below with your project code (e.g. t01)
+  #SBATCH --account=[budget code] 
   #SBATCH --partition=standard
   #SBATCH --qos=standard
-  #SBATCH --export=none
-
-  # Restore default module collection PrgEnv-cray
-  module -s restore /etc/cray-pe.d/PrgEnv-gnu
+  
+  # Setup the job environment (this module needs to be loaded before any other modules)
+  module load epcc-job-env
 
   # Set the number of threads to 1
   #   This prevents any threaded system libraries from automatically

--- a/research-software/namd/namd.rst
+++ b/research-software/namd/namd.rst
@@ -43,28 +43,26 @@ The following script will run a NAMD MD job using 4 nodes
 
 ::
 
-   #!/bin/bash
+  #!/bin/bash
 
-   # Request four nodes to run a job of 512 MPI tasks with 128 MPI
-   # tasks per node, here for maximum time 20 minutes.
-   # Remember to replace [budget code] below with your account code,
-   # e.g., '--account=t01-nell'
-   
-   #SBATCH --job-name=namd_test
-   #SBATCH --nodes=4
-   #SBATCH --ntasks=512
-   #SBATCH --tasks-per-node=128
-   #SBATCH --cpus-per-core=1
-   #SBATCH --time=00:20:00
-   
-   #SBATCH --account=[budget code]
-   #SBATCH --partition=standard
-   #SBATCH --qos=standard
-   
-   # Load the relevant NAMD module
-   # and launch the executable
+  # Request four nodes to run a job of 512 MPI tasks with 128 MPI
+  # tasks per node, here for maximum time 20 minutes.
 
-   module load namd/2020.1.2.3
+  #SBATCH --job-name=namd_test
+  #SBATCH --nodes=4
+  #SBATCH --tasks-per-node=128
+  #SBATCH --cpus-per-core=1
+  #SBATCH --time=00:20:00
 
-   srun ... namd2 input.namd
+  # Replace [budget code] below with your project code (e.g. t01)
+  #SBATCH --account=[budget code] 
+  #SBATCH --partition=standard
+  #SBATCH --qos=standard
+
+  # Setup the job environment (this module needs to be loaded before any other modules)
+  module load epcc-job-env
+
+  module load namd
+
+  srun ... namd2 input.namd
 

--- a/research-software/nwchem/nwchem.rst
+++ b/research-software/nwchem/nwchem.rst
@@ -58,10 +58,13 @@ standard partition. It assumes that the input file is called `test_calc.nw`.
   #SBATCH --cpus-per-task=1
   #SBATCH --time=00:20:00
 
+  # Replace [budget code] below with your project code (e.g. t01)
+  #SBATCH --account=[budget code] 
   #SBATCH --partition=standard
   #SBATCH --qos=standard
   
-  #SBATCH --account=[budget code]
+  # Setup the job environment (this module needs to be loaded before any other modules)
+  module load epcc-job-env
 
   # Load the NWChem module, avoid any unintentional OpenMP threading by
   # setting OMP_NUM_THREADS, and launch the code.

--- a/research-software/onetep/onetep.rst
+++ b/research-software/onetep/onetep.rst
@@ -49,9 +49,13 @@ assumes that the input file is called ``text_calc.dat``.
   #SBATCH --cpus-per-task=1
   #SBATCH --time=00:20:00
   
-  #SBATCH --account=[budget code]
+  # Replace [budget code] below with your project code (e.g. t01)
+  #SBATCH --account=[budget code] 
   #SBATCH --partition=standard
   #SBATCH --qos=standard
+  
+  # Setup the job environment (this module needs to be loaded before any other modules)
+  module load epcc-job-env
 
   # Load the ONETEP module
   module load onetep

--- a/research-software/openfoam/openfoam.rst
+++ b/research-software/openfoam/openfoam.rst
@@ -83,18 +83,20 @@ Each MPI task is allocated one core (``--cpus-per-task=1``).
 
 ::
 
-  #!/bin/bash --login
+  #!/bin/bash
   
   #SBATCH --nodes=4
-  #SBATCH --exclusive
   #SBATCH --tasks-per-node=128
   #SBATCH --cpus-per-task=1
   #SBATCH --time=00:10:00
   
+  # Replace [budget code] below with your project code (e.g. t01)
+  #SBATCH --account=[budget code] 
   #SBATCH --partition=standard
   #SBATCH --qos=standard
   
-  #SBATCH --export=none
+  # Setup the job environment (this module needs to be loaded before any other modules)
+  module load epcc-job-env
   
   # Load the appropriate modules and source the OpenFOAM bashrc file
   # The first line makes PrgEnv-gnu available on the back end nodes.
@@ -107,11 +109,6 @@ Each MPI task is allocated one core (``--cpus-per-task=1``).
   # Run OpenFOAM work
   
   srun --cpu-bind=cores interFoam -parallel
-
-
-Hints and tips
---------------
-
 
 Compiling OpenFOAM
 ------------------

--- a/research-software/qe/qe.rst
+++ b/research-software/qe/qe.rst
@@ -25,43 +25,37 @@ Using QE on ARCHER2
 QE is released under a GPL v2 license and is freely available to all ARCHER2
 users.
 
-
-
 Running parallel QE jobs
 ------------------------
 
 For example, the following script will run a QE ``pw.x`` job using 4 nodes
 (128x4 cores).
 
-.. warning::
-
-  The following SLURM script is a draft and requires verification
-
 ::
 
-   #!/bin/bash
+  #!/bin/bash
 
-   # Request 4 nodes to run a 512 MPI task job with 128 MPI tasks per node.
-   # The maximum walltime limit is set to be 20 minutes.
-   # Remember to replace [budget code] below with your own account code,
-   # e.g. '--account=t01-queenie`
+  # Request 4 nodes to run a 512 MPI task job with 128 MPI tasks per node.
+  # The maximum walltime limit is set to be 20 minutes.
 
-   #SBATCH --job-name=qe_test
-   #SBATCH --nodes=4
-   #SBATCH --ntasks=512
-   #SBATCH --ntasks-per-node=128
-   #SBATCH --cpus-per-task=1
-   #SBATCH --time=00:20:00
-   
-   #SBATCH --account=[budget code]
-   #SBATCH --partition=standard
-   #SBATCH --qos=standard
-   
-   # Load the relevant Quantum Espresso module
-   module restore /etc/cray-pe.d/PrgEnv-gnu
-   module load quantum-espresso
+  #SBATCH --job-name=qe_test
+  #SBATCH --nodes=4
+  #SBATCH --ntasks-per-node=128
+  #SBATCH --cpus-per-task=1
+  #SBATCH --time=00:20:00
 
-   srun pw.x < test_calc.in
+  # Replace [budget code] below with your project code (e.g. t01)
+  #SBATCH --account=[budget code] 
+  #SBATCH --partition=standard
+  #SBATCH --qos=standard
+
+  # Setup the job environment (this module needs to be loaded before any other modules)
+  module load epcc-job-env
+
+  # Load the relevant Quantum Espresso module
+  module load quantum-espresso
+
+  srun pw.x < test_calc.in
 
 
 Hints and tips

--- a/research-software/vasp/vasp.rst
+++ b/research-software/vasp/vasp.rst
@@ -92,22 +92,20 @@ The following script will run a VASP job using 2 nodes (128x2, 256 total cores).
   #!/bin/bash
 
   # Request 2 nodes (256 MPI tasks at 128 tasks per node) for 20 minutes.   
-  # Remember to replace [budget code] below with your account code,
-  # e.g., '--account=t01-victoria'
 
   #SBATCH --job-name=VASP_test
   #SBATCH --nodes=4
-  #SBATCH --ntasks=512
   #SBATCH --tasks-per-node=128
   #SBATCH --cpus-per-task=1
   #SBATCH --time=00:20:00
 
+  # Replace [budget code] below with your project code (e.g. t01)
+  #SBATCH --account=[budget code] 
   #SBATCH --partition=standard
   #SBATCH --qos=standard
   
-  #SBATCH --account=[budget code]
-  #SBATCH --partition=standard
-  #SBATCH --qos=standard
+  # Setup the job environment (this module needs to be loaded before any other modules)
+  module load epcc-job-env
   
   # Load the VASP module, avoid any unintentional OpenMP threading by
   # setting OMP_NUM_THREADS, and launch the code.
@@ -152,22 +150,20 @@ only MPI ranks and no OpenMP threading.
   #!/bin/bash
 
   # Request 2 nodes (256 MPI tasks at 128 tasks per node) for 20 minutes.   
-  # Remember to replace [budget code] below with your account code,
-  # e.g., '--account=t01-victoria'
 
   #SBATCH --job-name=VASP_test
   #SBATCH --nodes=4
-  #SBATCH --ntasks=512
   #SBATCH --tasks-per-node=128
   #SBATCH --cpus-per-task=1
   #SBATCH --time=00:20:00
 
+  # Replace [budget code] below with your project code (e.g. t01)
+  #SBATCH --account=[budget code] 
   #SBATCH --partition=standard
   #SBATCH --qos=standard
   
-  #SBATCH --account=[budget code]
-  #SBATCH --partition=standard
-  #SBATCH --qos=standard
+  # Setup the job environment (this module needs to be loaded before any other modules)
+  module load epcc-job-env
   
   # Load the VASP module, avoid any unintentional OpenMP threading by
   # setting OMP_NUM_THREADS, and launch the code.

--- a/user-guide/profile.rst
+++ b/user-guide/profile.rst
@@ -38,9 +38,6 @@ How to use CrayPat-lite
 
 4. Run the generated executable normally submitting a job.
 
-.. warning::
-
-  The following SLURM script is provisional and should be verified
 
 ::
 
@@ -55,7 +52,11 @@ How to use CrayPat-lite
    #SBATCH --account=[budget code]
    #SBATCH --partition=standard
    #SBATCH --qos=standard
+
+   # Setup the batch environment
+   module load epcc-job-env
    
+   # Launch the parallel program
    srun mpi_test.x
 
 5. Analyse the data
@@ -316,8 +317,9 @@ then open the Cray Apprentice2 data (``.ap2``) generated during the instrumentat
 
    [user@archer2]$ app2 jacobi+pat+12265-1573s/datafile.ap2
 
-    
-   
 Hardware Performance Counters
 -----------------------------
 
+.. note::
+
+   Information on hardware counters will be added soon.

--- a/user-guide/python.rst
+++ b/user-guide/python.rst
@@ -90,24 +90,27 @@ Example serial Python submission script
 
 ::
 
-    #!/bin/bash --login
+   #!/bin/bash --login
 
-    #SBATCH --name=python_test
-    #SBATCH --nodes=1
-    #SBATCH --tasks-per-node=1
-    #SBATCH --cpus-per-task=1
-    #SBATCH --time=00:10:00
+   #SBATCH --name=python_test
+   #SBATCH --nodes=1
+   #SBATCH --tasks-per-node=1
+   #SBATCH --cpus-per-task=1
+   #SBATCH --time=00:10:00
 
-    # Replace [budget code] below with your project code (e.g. t01)
-    #SBATCH --account=[budget code]
-    #SBATCH --partition=standard
-    #SBATCH --qos=standard
-    
-    # Load the Python module
-    module load cray-python
+   # Replace [budget code] below with your project code (e.g. t01)
+   #SBATCH --account=[budget code]
+   #SBATCH --partition=standard
+   #SBATCH --qos=standard
 
-    # Run your Python progamme
-    python python_test.py
+   # Setup the batch environment
+   module load epcc-job-env
+   
+   # Load the Python module
+   module load cray-python
+
+   # Run your Python progamme
+   python python_test.py
 
 mpi4py
 ~~~~~~
@@ -121,24 +124,27 @@ when it reaches the line ``from mpi4py import MPI``.
 
 ::
 
-    #!/bin/bash --login
-    # Slurm job options (job-name, compute nodes, job time)
-    #SBATCH --job-name=mpi4py_test
-    #SBATCH --nodes=1
-    #SBATCH --tasks-per-node=2
-    #SBATCH --cpus-per-task=1
-    #SBATCH --time=0:10:0
+   #!/bin/bash --login
+   # Slurm job options (job-name, compute nodes, job time)
+   #SBATCH --job-name=mpi4py_test
+   #SBATCH --nodes=1
+   #SBATCH --tasks-per-node=2
+   #SBATCH --cpus-per-task=1
+   #SBATCH --time=0:10:0
 
-    # Replace [budget code] below with your budget code (e.g. t01)
-    #SBATCH --account=[budget code]
-    #SBATCH --partition=standard
-    #SBATCH --qos=standard
+   # Replace [budget code] below with your budget code (e.g. t01)
+   #SBATCH --account=[budget code]
+   #SBATCH --partition=standard
+   #SBATCH --qos=standard
 
-    # Load the Python module
-    module load cray-python
+   # Setup the batch environment
+   module load epcc-job-env
 
-    # Run your Python programme
-    # Note that srun MUST be used to wrap the call to python, otherwise an error
-    # will occur
-    srun python mpi4py_test.py
+   # Load the Python module
+   module load cray-python
+
+   # Run your Python programme
+   # Note that srun MUST be used to wrap the call to python, otherwise an error
+   # will occur
+   srun python mpi4py_test.py
 

--- a/user-guide/scheduler.rst
+++ b/user-guide/scheduler.rst
@@ -314,6 +314,25 @@ Using the ``--export=none`` means that the behaviour of batch submissions
 should be repeatable. We strongly recommend its use.
 
 
+Using modules in the batch system: the ``epcc-job-env`` module
+--------------------------------------------------------------
+
+Batch jobs must be submitted in the work file system ``/work`` as the
+compute nodes do not have access to the ``/home`` file system. This has
+a knock-on effect on the behaviour of module collections, which the
+module system expects to find in a user's home directory. In order
+that the module system work correctly, batch scripts should contain
+
+.. code-block:: console
+
+  module load epcc-job-env
+
+**as the first module command in the script** to ensure that the
+environment is set correctly for the job. This will also ensure all
+relevant library paths are set correctly at run time. Note
+``module -s`` can be used to suppress the associated
+messages if desired.
+
 ``srun``: Launching parallel jobs
 ---------------------------------
 
@@ -334,26 +353,6 @@ A subset of example job submission scripts are included in full below. You
 can also download these examples at:
 
 .. TODO: add links to job submission scripts
-
-Using modules in the batch system: the ``epcc-job-env`` module
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Batch jobs must be submitted in the work file system ``/work`` as the
-compute nodes do not have access to the ``/home`` file system. This has
-a knock-on effect on the behaviour of module collections, which the
-module system expects to find in a user's home directory. In order
-that the module system work correctly, batch scripts should contain
-
-.. code-block:: console
-
-  module load epcc-job-env
-
-**as the first module command in the script** to ensure that the
-environment is set correctly for the job. This will also ensure all
-relevant library paths are set correctly at run time. Note
-``module -s`` can be used to suppress the associated
-messages if desired.
-
 
 Example: job submission script for MPI parallel job
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -636,8 +635,6 @@ Best practices for job submission
 
 This guidance is adapted from
 `the advice provided by NERSC <https://docs.nersc.gov/jobs/best-practices/>`__
-
-.. TODO: update to match ARCHER2
 
 Time Limits
 ~~~~~~~~~~~


### PR DESCRIPTION
This PR adds the `epcc-job-env` module to example scripts and makes the examples more consistent across the documentation. Resolves #106 