### PR TITLE
Update scheduler.md

### DIFF
--- a/docs/user-guide/scheduler.md
+++ b/docs/user-guide/scheduler.md
@@ -152,7 +152,7 @@ ARCHER2.
 | QoS      | Max Nodes Per Job | Max Walltime | Jobs Queued | Jobs Running | Partition(s) |
 | -------- | ----------------- | ------------ | ----------- | ------------ | ------------ |
 | standard | 940               | 24 hrs       | 64          | 16           | standard     |
-| short    | 8                 | 20 mins      | 2           | 2            | short        |
+| short    | 8                 | 20 mins      | 2           | 1            | standard     |
 | long     | 16                | 48 hrs       | 16          | 16           | standard     |
 
 !!! warning


### PR DESCRIPTION
Fixed:
- https://docs.archer2.ac.uk/user-guide/scheduler/#partitions: the references to the short partition has been removed. There’s only one partition on the 4Cab system, “standard”.
- https://docs.archer2.ac.uk/user-guide/scheduler/#quality-of-service-qos: the short QoS has a maximum “Jobs Running” limit has been corrected to 1.