### PR TITLE
Fix edit uri and broken links

### DIFF
--- a/docs/quick-start/quickstart-developers.md
+++ b/docs/quick-start/quickstart-developers.md
@@ -294,7 +294,7 @@ The available `perftools-lite` modules are:
 
 Links to other documentation you may find useful:
 
-  - [ARCHER2 User and Best Practice Guide](../user-guide/overview.md) -
+  - [ARCHER2 User and Best Practice Guide](../user-guide/) -
     Covers all aspects of use of the ARCHER2 service. This includes
     fundamentals (required by all users to use the system effectively),
     best practice for getting the most out of ARCHER2, and more advanced

--- a/docs/user-guide/dev-environment.md
+++ b/docs/user-guide/dev-environment.md
@@ -406,7 +406,7 @@ access to software libraries if available.
 
 !!! tip
     More information on the different software libraries on ARCHER2 can
-    be found in the [Software libraries](../software-libraries/overview.md)
+    be found in the [Software libraries](../software-libraries/)
     section of the user guide.
 
 ## Build instructions for software on ARCHER2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ extra_css:
 site_name: ARCHER2 User Documentation
 repo_url: https://github.com/ARCHER2-HPC/archer2-docs
 repo_name: ARCHER2-HPC/archer2-docs
+edit_uri: edit/main/docs/
 extra:
   social:
     - icon: fontawesome/brands/github


### PR DESCRIPTION
The edit link pointed to the `master` branch rather than the `main` branch. Two other documentation links have been fixed too.