### PR TITLE
scheduler.md: updated long max nodes per job in table, checked by sacctmgr

### DIFF
--- a/docs/user-guide/scheduler.md
+++ b/docs/user-guide/scheduler.md
@@ -153,7 +153,7 @@ ARCHER2.
 | -------- | ----------------- | ------------ | ----------- | ------------ | ------------ |
 | standard | 940               | 24 hrs       | 64          | 16           | standard     |
 | short    | 8                 | 20 mins      | 2           | 1            | standard     |
-| long     | 16                | 48 hrs       | 16          | 16           | standard     |
+| long     | 64                | 48 hrs       | 16          | 16           | standard     |
 
 !!! warning
     If you want to use the `short` QoS then you also need to add the


### PR DESCRIPTION
Not 100% sure maxtres is the right figure here, so if someone can confirm/deny that would be good.
```
 sacctmgr show qos long format=name,maxtres,maxwall,maxsubmitpu,maxjobspu
      Name       MaxTRES     MaxWall MaxSubmitPU MaxJobsPU
---------- ------------- ----------- ----------- ---------
      long       node=64  2-00:00:00          16        16
```