### PR TITLE
Fixed links to HPC-UK build instructions

### DIFF
--- a/docs/research-software/code-saturne/code-saturne.md
+++ b/docs/research-software/code-saturne/code-saturne.md
@@ -100,5 +100,5 @@ The latest instructions for building Code\_Saturne on ARCHER2 may be found in
 the GitHub repository of build instructions:
 
    - [Build instructions for Code\_Saturne on
-     GitHub](https://github.com/hpc-uk/build-instructions/tree/main/Code_Saturne)
+     GitHub](https://github.com/hpc-uk/build-instructions/tree/main/apps/Code_Saturne)
 

--- a/docs/research-software/elk/elk.md
+++ b/docs/research-software/elk/elk.md
@@ -84,4 +84,4 @@ The latest instructions for building ELK on ARCHER2 may be found in
 the GitHub repository of build instructions:
 
    - [Build instructions for ELK on
-     GitHub](https://github.com/hpc-uk/build-instructions/tree/master/ELK)
+     GitHub](https://github.com/hpc-uk/build-instructions/tree/main/apps/ELK)

--- a/docs/research-software/gromacs/gromacs.md
+++ b/docs/research-software/gromacs/gromacs.md
@@ -86,4 +86,4 @@ The latest instructions for building GROMACS on ARCHER2 may be found in
 the GitHub repository of build instructions:
 
    - [Build instructions for GROMACS on
-     GitHub](https://github.com/hpc-uk/build-instructions/tree/master/GROMACS)
+     GitHub](https://github.com/hpc-uk/build-instructions/tree/main/apps/GROMACS)

--- a/docs/research-software/namd/namd.md
+++ b/docs/research-software/namd/namd.md
@@ -109,3 +109,11 @@ should be 128.
 If you cannot run the pure MPI version of NAMD, then the optimal
 values of (`tasks-per-node`, `cpus-per-task`) are likely to be either
 (32,4), (16,8) or (8,16).
+
+## Compiling NAMD
+
+The latest instructions for building NAMD on ARCHER2 may be found in
+the GitHub repository of build instructions:
+
+   - [Build instructions for CASTEP on
+     GitHub](https://github.com/hpc-uk/build-instructions/tree/main/apps/NAMD)

--- a/docs/research-software/nwchem/nwchem.md
+++ b/docs/research-software/nwchem/nwchem.md
@@ -68,4 +68,4 @@ The latest instructions for building NWChem on ARCHER2 may be found in
 the GitHub repository of build instructions:
 
    - [Build instructions for NWChem on
-     GitHub](https://github.com/hpc-uk/build-instructions/tree/master/NWChem)
+     GitHub](https://github.com/hpc-uk/build-instructions/tree/main/apps/NWChem)

--- a/docs/research-software/onetep/onetep.md
+++ b/docs/research-software/onetep/onetep.md
@@ -73,4 +73,4 @@ The latest instructions for building CASTEP on ARCHER2 may be found in
 the GitHub repository of build instructions:
 
    - [Build instructions for ONETEP on
-     GitHub](https://github.com/hpc-uk/build-instructions/tree/master/ONETEP)
+     GitHub](https://github.com/hpc-uk/build-instructions/tree/main/apps/ONETEP)

--- a/docs/research-software/qe/qe.md
+++ b/docs/research-software/qe/qe.md
@@ -62,4 +62,4 @@ directory you wish. This can be done by adding the following line
 The latest instructions for building QE on ARCHER2 can be found in the
 GitHub repository of build instructions:
 
-   - [Build instructions for Quantum Espresso](https://github.com/hpc-uk/build-instructions/tree/main/QuantumEspresso)
+   - [Build instructions for Quantum Espresso](https://github.com/hpc-uk/build-instructions/tree/main/apps/QuantumEspresso)

--- a/docs/research-software/vasp/vasp.md
+++ b/docs/research-software/vasp/vasp.md
@@ -156,7 +156,7 @@ If you wish to compile your own version of VASP on ARCHER2 (either VASP
 5 or VASP 6) you can find information on how we compiled the central
 versions in the build instructions GitHub repository. See:
 
-   - [Build instructions for VASP on GitHub](https://github.com/hpc-uk/build-instructions/tree/main/VASP)
+   - [Build instructions for VASP on GitHub](https://github.com/hpc-uk/build-instructions/tree/main/apps/VASP)
 
 ## Tips for using VASP on ARCHER2
 


### PR DESCRIPTION
Some research software pages had out-of-date links to build instructions in the HPC-UK repo. I've updated them.