### PR TITLE
Updates two known issues and corrects FAQ

### DIFF
--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -82,7 +82,7 @@ of its value when it fails (so if you have ``--tasks-per-node=128``, reduce it
 to ``--tasks-per-node=64``).
 
 If the problem persists on underpopulated node, this may be a result of a
-known issue with the default version of MPICH. You can find more information
+known issue with the underlying libfabric on ARCHER2. You can find more information
 on this issue (including a temporary workaround) in the
 [Known Issues](https://docs.archer2.ac.uk/known-issues/) section.
 

--- a/docs/known-issues/index.md
+++ b/docs/known-issues/index.md
@@ -8,7 +8,7 @@ active investigation by HPE Cray and the wider service.
 
 ### OOM due to memory leak in libfabric (Added: 2022-02-23)
 
-There is an underlying memory leak in the version of libfabric on ArCHER2 (that comes as part of the underlying
+There is an underlying memory leak in the version of libfabric on ARCHER2 (that comes as part of the underlying
 SLES operating system) which can cause jobs to fail with an OOM (Out Of Memory) error. This issue will be addressed
 in a future upgrade of the ARCHER2 operating system. You can workaround this issue by setting the following 
 environment variable in your job submission scripts:
@@ -37,8 +37,11 @@ module load cray-fftw
 export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH
 ```
 
-This will make sure that the application uses the correct libraries rather than those that are incorrectly linked from the
-default location at `/opt/cray/pe/lib64` which is encoded into the executable's `RUNPATH`.
+THe issue arises because the compilers encode a default path to libraries (`/opt/cray/pe/lib64`) into the `RUNPATH` of 
+the executable so that you do not need to load all the library module dependencies at runtime. The libraries that the
+executable finds at `/opt/cray/pe/lib64` are soft links to the default versions of the libraries. There is an error in 
+the soft link to the FFTW libraries in this directory such they point to the Haswell version of the FFTW libraries rather
+than the AMD EPYC (Rome) versions of the libraries.
 
 ### Occasionally user jobs can cause compute nodes to crash (Added: 2021-11-22)
 

--- a/docs/known-issues/index.md
+++ b/docs/known-issues/index.md
@@ -37,7 +37,7 @@ module load cray-fftw
 export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH
 ```
 
-THe issue arises because the compilers encode a default path to libraries (`/opt/cray/pe/lib64`) into the `RUNPATH` of 
+The issue arises because the compilers encode a default path to libraries (`/opt/cray/pe/lib64`) into the `RUNPATH` of 
 the executable so that you do not need to load all the library module dependencies at runtime. The libraries that the
 executable finds at `/opt/cray/pe/lib64` are soft links to the default versions of the libraries. There is an error in 
 the soft link to the FFTW libraries in this directory such they point to the Haswell version of the FFTW libraries rather

--- a/docs/known-issues/index.md
+++ b/docs/known-issues/index.md
@@ -6,6 +6,40 @@ active investigation by HPE Cray and the wider service.
 
 ## Open Issues
 
+### OOM due to memory leak in libfabric (Added: 2022-02-23)
+
+There is an underlying memory leak in the version of libfabric on ArCHER2 (that comes as part of the underlying
+SLES operating system) which can cause jobs to fail with an OOM (Out Of Memory) error. This issue will be addressed
+in a future upgrade of the ARCHER2 operating system. You can workaround this issue by setting the following 
+environment variable in your job submission scripts:
+
+```
+export FI_MR_CACHE_MAX_COUNT=0
+```
+
+This may come with a performance penalty (though in many cases, we have not seen a noticeable performance impact).
+
+If you continue to see OOM errors after setting this environment variable and do not believe that your application
+should be requesting too much memory then please
+[contact the service desk](https://www.archer2.ac.uk/support-access/servicedesk.html)
+
+### Default FFTW library points to Intel Haswell version rather than AMD Rome at runtime (Added: 2022-02-23)
+
+By default, and at runtime, the standard FFTW library version (from the module `cray-fftw`) will link to a version of the
+FFTW library optimised for the Intel Haswell architecture rather than the AMD EPYC architecture. This does not cause 
+errors as the instruction set is compatible between the two architectures but may not provide optimal performance. The
+performance differences observed have been small (&lt; 5%) but if you want to ensure that applications using the `cray-fftw`
+module use the correct version of the libraries at runtime, you should add the following lines to your job submission
+script:
+
+```
+module load cray-fftw
+export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH
+```
+
+This will make sure that the application uses the correct libraries rather than those that are incorrectly linked from the
+default location at `/opt/cray/pe/lib64` which is encoded into the executable's `RUNPATH`.
+
 ### Occasionally user jobs can cause compute nodes to crash (Added: 2021-11-22)
 
 In rare circumstances, it is possible for a user job to crash the compute nodes on which it is running. This is only evident to the user as a failed job: there is no obvious sign that the nodes have crashed. Therefore, if we identify a user whose jobs are causing nodes to crash, we may need to work with them to stop this happening.
@@ -49,8 +83,6 @@ There are several outstanding issues for the centrally installed Research Softwa
 Users should also check individual software pages, for known limitations/ caveats, for the use of software on the Cray EX platform and Cray Linux Environment.
 
 ### Issues with RPATH for non-default library versions
-
-- **Systems affected:** ARCHER2 full system, ARCHER2 4-cabinet system
 
 When you compile applications against non-default versions of libraries within the HPE
 Cray software stack and use the environment variable `CRAY_ADD_RPATH=yes` to try and encode


### PR DESCRIPTION
Adds notes on libfabric memory leak issue and fact that FFTW points to Haswell version at runtime.