### PR TITLE
Update arm-forge.md

### DIFF
--- a/docs/data-tools/arm-forge.md
+++ b/docs/data-tools/arm-forge.md
@@ -37,13 +37,13 @@ the SLURM queue system. These steps should be performed in the `/work`
 file system on ARCHER2.
 
 It is recommended that these commands are performed in the top-level work
-file system directory for the user account, i.e., `${HOME/home/work}`.
+file system directory for the user account, i.e., `${/work/.../}`.
 ```bash
 module load arm/forge
-cd ${HOME/home/work}
+cd ${work/.../}
 source ${FORGE_DIR}/config-init
 ```
-This will create a directory `${HOME/home/work}/.allinea` that contains the following files.
+This will create a directory `${/work/...}/.allinea` that contains the following files.
 ```output
 system.config  user.config
 ```
@@ -53,6 +53,16 @@ The directory will also store other relevant files when Forge is run.
     The `config-init` script will output a warning, `...failed to read system config`.
     Please ignore: subsequent output should indicate that the new configuration
     files have been created.
+    
+Once you have created this directory, you also need to modify the `system.config` file in the directory `${/work/.../.allinea}`, editing the line
+```bash
+shared directory = ~
+```
+To instead point to your `${/work/.../.allinea}` directory, i.e. if you are in the `z19` project, that would be:
+
+```bash
+shared directory = /work/z19/z19/$USER/.allinea
+```
 
 ### Using DDT
 


### PR DESCRIPTION
Updating the arm forge setup instructions to include information about configuring the `shared directory` variable in the `system.config` file to ensure the DDT debugger can connect to the client from a running application when a job is submitted to the batch system from the GUI.