### PR TITLE
Prevent multithreading and place tasks with block:block distribution in examples of hybrid subjob submission scripts

### DIFF
--- a/docs/user-guide/scheduler.md
+++ b/docs/user-guide/scheduler.md
@@ -1095,6 +1095,8 @@ this example would look like:
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=128
 #SBATCH --cpus-per-task=1
+#SBATCH --hint=nomultithread
+#SBATCH --distribution=block:block
 
 # Replace [budget code] below with your budget code (e.g. t01)
 #SBATCH --account=[budget code]  

--- a/docs/user-guide/scheduler.md
+++ b/docs/user-guide/scheduler.md
@@ -1149,6 +1149,8 @@ this example would look like:
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=64
 #SBATCH --cpus-per-task=2
+#SBATCH --hint=nomultithread
+#SBATCH --distribution=block:block
 
 # Replace [budget code] below with your budget code (e.g. t01)
 #SBATCH --account=[budget code]  


### PR DESCRIPTION
Two examples are given in the documentation of running job scripts with multiple `srun`s for hybrid MPI+OpenMP subjobs. As-is, these place threads on the same cores as multithreading is allowed. Adding `--hint=nomultithread` prevents this. Using `--distribution=block:block` distribution also provides a sensible placement of tasks.

`export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK` is not necessary as `cpus-per-task` is set directly as an `srun` option in these examples.

Tested on the TDS.