### PR TITLE
Note on Python modules not being found when running on compute nodes

### DIFF
--- a/docs/user-guide/python.md
+++ b/docs/user-guide/python.md
@@ -106,6 +106,11 @@ export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK
 srun --distribution=block:block --hint=nomultithread python ${SLURM_SUBMIT_DIR}/myvenv-script.py
 ```
 
+!!! tip
+    If you find that a module you've installed to a virtual environment on `/work` isn't found when running a job, it may be that it was previously installed to the default location of `$HOME/.local` which is not mounted on the compute nodes. This can be an issue as `pip` will reuse any modules found at this default location rather than reinstall them into a virtual environment. Thus, even if the virtual environment is on `/work`, a module you've asked for may actually be located on `/home`.
+
+    You can check a module's install location and its dependencies with `pip show`, for example `pip show matplotlib`. You may then run `pip uninstall matplotlib` while no virtual environment is active to uninstall it from `$HOME/.local`, and then re-run `pip install matplotlib` while your virtual environment on `/work` is active to reinstall it there. You will need to do this for any modules installed on `/home` that will use either directly or indirectly. Remember you can check all your installed modules with `pip list`.
+
 Lastly, the environment being extended does not have to come from one of the centrally-installed `cray-python` modules.
 You can also create a local virtual environment based on one of the Machine Learning (ML) modules, e.g., `tensorflow`
 or `pytorch`. One extra command is required; it is issued immediately after the `python -m venv ...` command.


### PR DESCRIPTION
Several queries have come in since the upgrade with Python modules installed by users to venvs on `/work` not being found during jobs. This was due to previous `pip install --user` commands having installed them to `$HOME/.local`. `pip` will reuse modules from this location rather than install again to a venv. This tip provides some help.

`pip install --ignore-installed` seemed like it might be an easier way to deal with the problem, forcing it to install to the venv without consideration for the one in `$HOME/.local`, but on testing with `matplotlib` the module loads but still wants configs from `$HOME`, so not everything is reconfigured to the venv's location. Uninstalling and reinstalling seems like the best option. Deleting `$HOME/.local` is another possibility as long as nothing else of importance is in there. As it's potentially dangerous I thought it best not to recommend here in the documentation.