### PR TITLE
Overlap

### DIFF
--- a/docs/data-tools/paraview.md
+++ b/docs/data-tools/paraview.md
@@ -54,7 +54,7 @@ Then load the ParaView module and start pvserver with the srun command,
 
 ```
 auser@nid001023:/work/t01/t01/auser> module load paraview
-auser@nid001023:/work/t01/t01/auser> srun --oversubscribe -n 4 pvserver --mpi --force-offscreen-rendering
+auser@nid001023:/work/t01/t01/auser> srun --overlap --oversubscribe -n 4 pvserver --mpi --force-offscreen-rendering
 Waiting for client...
 Connection URL: cs://nid001023:11111
 Accepting connection(s): nid001023:11111

--- a/docs/user-guide/scheduler.md
+++ b/docs/user-guide/scheduler.md
@@ -1796,10 +1796,10 @@ of `srun` is required to launch a parallel job in the allocation.
 
 !!! note
     When using `srun` within an interactive `srun` session, you will need to 
-    include the `--oversubscribe` flag and specify the number of cores you want 
+    include both the `--overlap` and `--oversubscribe` flags, and specify the number of cores you want 
     to use:
     ```
-    auser@nid001261:/work/t01/t01/auser> srun --oversubscribe --distribution=block:block \
+    auser@nid001261:/work/t01/t01/auser> srun --overlap --oversubscribe --distribution=block:block \
                     --hint=nomultithread --ntasks=128 ./my_mpi_executable.x
     ```
 

--- a/docs/user-guide/scheduler.md
+++ b/docs/user-guide/scheduler.md
@@ -1803,6 +1803,11 @@ of `srun` is required to launch a parallel job in the allocation.
                     --hint=nomultithread --ntasks=128 ./my_mpi_executable.x
     ```
 
+Without `--overlap` the second `srun` will block until the first one
+has completed. Since your interactive session was launched with `srun`
+this means it will never actually start -- you will get repeated
+warnings that "Requested nodes are busy".
+
 When finished, type `exit` to relinquish the allocation and control will
 be returned to the front end.
 


### PR DESCRIPTION
An srun within an interactive srun now needs --overlap as well as --oversubscribe. This affects interactive instructions and those for paraview.