### PR TITLE
Render compiler exports as code in Quickstart for developers

### DIFF
--- a/docs/quick-start/quickstart-developers.md
+++ b/docs/quick-start/quickstart-developers.md
@@ -23,11 +23,11 @@ line, in build scripts, or in configure options. It could be helpful to
 set some or all of the following environment variables before running a
 build to ensure that the build tool is aware of the wrappers.
 
-  export CC=cc
-  export CXX=CC
-  export FC=ftn
-  export F77=ftn
-  export F90=ftn
+    export CC=cc
+    export CXX=CC
+    export FC=ftn
+    export F77=ftn
+    export F90=ftn
 
 `man` pages are available for each wrapper. You can also see the full
 set of compiler and linker options being used by passing the


### PR DESCRIPTION
The export statements for compiler variables in [Quickstart for developers](https://docs.archer2.ac.uk/quick-start/quickstart-developers/) renders as a line of text:

> export CC=cc export CXX=CC export FC=ftn export F77=ftn export F90=ftn

where I presume the intended effect was a code block like

```
export CC=cc 
export CXX=CC 
export FC=ftn 
export F77=ftn 
export F90=ftn
```

I think this is just because the source indents these lines by 2 spaces, rather than 4, and this PR fixes the indentation to 4 spaces.