### PR TITLE
Fix link to AMD EPYC 7002 Tuning Guide

### DIFF
--- a/docs/user-guide/hardware.md
+++ b/docs/user-guide/hardware.md
@@ -53,7 +53,7 @@ Each socket contains eight *Core Complex Dies* (CCDs) and one I/O die (IOD). Eac
 
 More information on the architecture of the AMD EPYC Zen2 processors:
 
-* [HPC Tuning Guide for AMD EPYC 7002 Processors](https://www.amd.com/system/files/documents/amd-epyc-7002-tg-hpc-56827.pdf)
+* [HPC Tuning Guide for AMD EPYC 7002 Processors](https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/tuning-guides/amd-epyc-7002-tg-hpc-56827.pdf)
 
 ## AMD Zen2 microarchitecture
 


### PR DESCRIPTION
Not only is the original link broken, the tuning guide for the 7002 series can no longer be found when searching the AMD docs hub. Uncertain whether the link fixed by this merge request will remain functional for the duration of ARCHER2 service, should consider hosting a copy of the file within this repo if permissible. 