### PR TITLE
Make Spack documentation visible.

### DIFF
--- a/docs/data-tools/index.md
+++ b/docs/data-tools/index.md
@@ -16,5 +16,6 @@ OpenMP or pthreads mutli-threaded applications (and also hydrid MPI/OpenMP)
 - [ParaView](paraview.md): A data visualisation and analysis package 
 - [Blender](blender.md): A generalist 3D software that can be used for scientific visualisations
 - [R](cray-r.md): The R statistical language
+- [Spack](spack.md): A tool to install and manage software packages
 - [VisiData](visidata.md): An interactive multitool for tabular data
 - [VMD](vmd.md): A visualisation and analysis program for Molecular Dynamics

--- a/docs/data-tools/spack.md
+++ b/docs/data-tools/spack.md
@@ -18,9 +18,11 @@ information on using Spack itself please see the [developers'
 documentation](https://spack.readthedocs.io/en/latest/).
 
 !!! important
-    As ARCHER2's central Spack installation is still in an experimental stage
-    please be aware that we cannot guarantee that it will work with full
-    functionality and we may not be able to provide support.
+    As ARCHER2's central Spack installation is still in an
+    experimental stage please be aware that we cannot guarantee that it will
+    work with full functionality and we may not be able to provide support. The
+    centrally-provided configuration and Spack-installed software may be subject
+    to change.
 
 ## Activating Spack
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -128,6 +128,7 @@ nav:
     - "Julia": data-tools/julia.md
     - "ParaView": data-tools/paraview.md
     - "R": data-tools/cray-r.md
+    - "Spack": data-tools/spack.md
     - "VisiData": data-tools/visidata.md
     - "VMD": data-tools/vmd.md
   - "Essential Skills": essentials/index.md


### PR DESCRIPTION
Adds a link to the Spack documentation to the sidebar menu and to the tool overview. I've also slightly expanded the warning near the top of the page to warn that work is still ongoing and things might change.