### PR TITLE
doc: fix gpu multi-node job script

### DIFF
--- a/docs/user-guide/gpu.md
+++ b/docs/user-guide/gpu.md
@@ -587,7 +587,7 @@ on the compute node architecture.
 #!/bin/bash
 
 #SBATCH --job-name=multi-GPU
-#SBATCH --gpus=4
+#SBATCH --gpus=8
 #SBATCH --nodes=2
 #SBATCH --exclusive
 #SBATCH --time=00:20:00


### PR DESCRIPTION
Fix the GPU multi-node job script example to use 8 GPUs across two nodes